### PR TITLE
Raids overview - DB+config.php variable is required!

### DIFF
--- a/commands/raid.php
+++ b/commands/raid.php
@@ -246,7 +246,7 @@ if ($update['message']['chat']['type'] == 'private' || $update['callback_query']
     }
 
     // Send the message.
-    send_message($update['message']['chat']['id'], $text, $keys, ['reply_to_message_id' => $reply_to, 'reply_markup' => ['selective' => true, 'one_time_keyboard' => true]]);
+    send_message($update['message']['chat']['id'], $text, $keys, ['reply_to_message_id' => $reply_to, 'reply_markup' => ['selective' => true, 'one_time_keyboard' => true], 'disable_web_page_preview' => 'true']);
 }
 
 exit;

--- a/config.php.example
+++ b/config.php.example
@@ -29,6 +29,7 @@ define ('RAID_POKEMON_DURATION_SHORT', '45'); //minutes till pokemon leave
 define ('RAID_DURATION_CLOCK_STYLE',    true); // True: Clocktime style, e.g. "18:34" --- False: Minute style, e.g. "still 0:34"
 
 define('CLEANUP',           false); // must be true for cleanup
+define('CLEANUP_LOGFILE',   '/var/log/tg-bots/dev-raid-bot-cleanup.log');
 define('CLEANUP_SECRET',    'your-cleanup-secret/passphrase');
 define('CLEANUP_TELEGRAM',  true);
 define('CLEANUP_TIME_TG',   '10'); // minutes after RAID ended

--- a/constants.php
+++ b/constants.php
@@ -41,6 +41,7 @@ $pokemon = array(
         getTranslation('entei'),
         getTranslation('suicune'),
         getTranslation('groudon'),
+        getTranslation('kyogre'),
         getTranslation('egg_5')
     ),
     '4' => array(

--- a/debug.php
+++ b/debug.php
@@ -35,7 +35,7 @@ function my_query($query)
  * @param $val
  * @param string $type
  */
-function debug_log($val, $type = '*')
+function debug_log($val, $type = '*', $cleanup_log = false)
 {
     // Write to log only if debug is enabled.
     if (DEBUG === true) {
@@ -56,7 +56,22 @@ function debug_log($val, $type = '*')
         if (gettype($val) != 'string') $val = var_export($val, 1);
         $rows = explode("\n", $val);
         foreach ($rows as $v) {
-            error_log('[' . $date . '][' . getmypid() . '] ' . $bl . $type . ' ' . $v . "\n", 3, CONFIG_LOGFILE);
+            if ($cleanup_log == true) {
+                error_log('[' . $date . '][' . getmypid() . '] ' . $bl . $type . ' ' . $v . "\n", 3, CLEANUP_LOGFILE);
+            } else {
+                error_log('[' . $date . '][' . getmypid() . '] ' . $bl . $type . ' ' . $v . "\n", 3, CONFIG_LOGFILE);
+            }
         }
     }
+}
+
+/**
+ * Write cleanup log.
+ * @param $val
+ * @param string $type
+ * @param bool $cleanup_log
+ */
+function cleanup_log($val, $type = '*')
+{
+    debug_log($val, $type, $cleanup_log = true);
 }

--- a/functions.php
+++ b/functions.php
@@ -70,7 +70,7 @@ function send_message($chat_id, $text = array(), $inline_keyboard = false, $merg
     debug_log($reply_json, '>');
 
     // Send request to telegram api.
-    curl_json_request($reply_json);
+    return curl_json_request($reply_json);
 }
 
 /**
@@ -503,6 +503,20 @@ function curl_json_request($json)
 	        } else {
 		    debug_log('Missing input! Cannot call cleanup preparation!');
 		}
+            }
+
+            // Check if text starts with getTranslation('raid_overview_for_chat') and inline keyboard is empty
+            $translation = getTranslation('raid_overview_for_chat');
+            $translation_length = strlen($translation);
+            $text = substr($response['result']['text'], 0, $translation_length);
+            if ($text == $translation && empty($json_message['reply_markup']['inline_keyboard'])) {
+                debug_log('Detected overview message!');
+                debug_log('Chat_ID: ' . $chat_id);
+                debug_log('Message_ID: ' . $message_id);
+
+                // Write raid overview data to database
+                debug_log('Adding overview info to database now!');
+                insert_overview($chat_id, $message_id);
             }
 	}
     }

--- a/index.php
+++ b/index.php
@@ -72,7 +72,7 @@ debug_log('Update user: ' . $userUpdate);
 
 // Cleanup request received.
 if (isset($update['cleanup']) && CLEANUP == true) {
-    debug_log('Cleanup process request received...');
+    cleanup_log('Cleanup process request received...');
     // Check access to cleanup of bot
     if ($update['cleanup']['secret'] == CLEANUP_SECRET) {
 	// Get telegram cleanup value if specified.
@@ -88,7 +88,7 @@ if (isset($update['cleanup']) && CLEANUP == true) {
 	    $database = 2;
 	}
         // Run cleanup
-        debug_log('Calling cleanup process now!');
+        cleanup_log('Calling cleanup process now!');
         run_cleanup($telegram, $database);
     }
     // Exit after cleanup

--- a/language.json
+++ b/language.json
@@ -514,6 +514,11 @@
 		"DE": "Aktuell sind keine laufenden Raids im System!",
 		"EN": "No active raids found in the system!"		
 	},
+	"no_active_raids_shared" : {
+		"NL": "Geen van de actieve raid is gedeeld!",
+		"DE": "Keines der aktiven Raids wurde geteilt!",
+		"EN": "None of the active raids was shared!"
+	},
 	"no_active_raids" : {
 		"NL": "Geen actieve raids!",
 		"DE": "Aktuell gibt es keine Raids!",
@@ -650,57 +655,57 @@
 		"EN": "Info about this moderator:"
 	},
 	"overview_share" : {
-		"NL": "INSERT_TRANSLATION",
+		"NL": "Overzicht delen",
 		"DE": "Übersicht teilen",
 		"EN": "Share overview"
 	},
 	"overview_delete" : {
-		"NL": "INSERT_TRANSLATION",
+		"NL": "Vewijder overzicht",
 		"DE": "Übersicht löschen",
 		"EN": "Delete overview"
 	},
 	"raids_list_share_overview" : {
-		"NL": "INSERT_TRANSLATION",
+		"NL": "Geef de actieve raid weer als een lijst of deel / verwijder het raid overzicht",
 		"DE": "Aktive Raids als Liste anzeigen oder die Raid-Übersicht pro Chat teilen / löschen",
 		"EN": "Show active raids as list or share / delete the raid overview per chat"
 	},
 	"list_all_active_raids" : {
-		"NL": "INSERT_TRANSLATION",
+		"NL": "Alle actieve raids",
 		"DE": "Alle aktiven Raids",
 		"EN": "All active raids"
 	},
 	"list_all_overviews" : {
-		"NL": "INSERT_TRANSLATION",
+		"NL": "Totaal raid overzicht",
 		"DE": "Alle Raid-Übersichten",
 		"EN": "All raid overviews"
 	},
 	"delete_raid_overview_for_chat" : {
-		"NL": "INSERT_TRANSLATION",
+		"NL": "Verwijder raid overzicht voor",
 		"DE": "Raid-Übersicht löschen für",
 		"EN": "Delete raid overview for"
 	},
 	"no_overviews_found" : {
-		"NL": "INSERT_TRANSLATION",
+		"NL": "Geen raid overzicht gevonden in het systeem!",
 		"DE": "Keine Raid-Übersichten im System gefunden!",
 		"EN": "No raid overviews found in the system!"
 	},
 	"overview_successfully_deleted" : {
-		"NL": "INSERT_TRANSLATION",
+		"NL": "Raid overzicht is succesvol verwijderd!",
 		"DE": "Raid-Übersicht wurde erfolgreich gelöscht!",
 		"EN": "Raid overview was successfully deleted!"
 	},
 	"overview_deletion_was_canceled" : {
-		"NL": "INSERT_TRANSLATION",
+		"NL": "Het verwijderen van het raid overzicht is gestopt!",
 		"DE": "Löschung der Raid-Übersicht wurde abgebrochen!",
 		"EN": "Deletion of the raid overview was canceled!"
 	},
 	"raid_overview_for_chat" : {
-		"NL": "INSERT_TRANSLATION",
+		"NL": "Raid overzicht voor",
 		"DE": "Raid-Übersicht für",
 		"EN": "Overview of raids for"
 	},
 	"successfully_shared" : {
-		"NL": "INSERT_TRANSLATION",
+		"NL": "Succesvol gedeeld!",
 		"DE": "Erfolgreich geteilt!",
 		"EN": "Successfully shared!"
 	},

--- a/language.json
+++ b/language.json
@@ -45,7 +45,7 @@
 		"EN": "Raid done"		
 	},
 	"here" : {
-		"DE": "Ben er",
+		"NL": "Ben er",
 		"DE": "Bin da",
 		"EN": "Here"		
 	},
@@ -115,12 +115,12 @@
 		"EN": "Raid egg opens on"		
 	},
 	"raid_egg_opens_at" : {
-		"NL": "at",
+		"NL": "om",
 		"DE": "um",
 		"EN": "at"		
 	},
 	"raid_until" : {
-		"NL": "Raid until",
+		"NL": "Raid tot",
 		"DE": "Raid bis",
 		"EN": "Raid until"		
 	},
@@ -228,6 +228,11 @@
     		"NL": "Groudon",
     		"DE": "Groudon",
     		"EN": "Groudon"
+  	},
+  	"kyogre" : {
+    		"NL": "Kyogre",
+    		"DE": "Kyogre",
+    		"EN": "Kyogre"
   	},
 	"egg_5" : {
 		"NL": "Level 5 Ei",
@@ -350,17 +355,17 @@
 		"EN": "First letter selected."		
 	},
 	"raid_creation_started_at" : {
-		"NL": "Raid creation was started at",
+		"NL": "Raid aanmaak is gestart om",
 		"DE": "Das Raid wird angelegt seit",
 		"EN": "Raid creation was started at"
 	},
 	"raid_being_created_by_other_user" : {
-		"NL": "Another user is currently creating a raid for this gym:",
+		"NL": "Een andere gebruiker is een raid voor deze gym aan het maken:",
 		"DE": "Ein Raid für diese Arena wird gerade angelegt von:",
 		"EN": "Another user is currently creating a raid for this gym:"
 	},
 	"raid_already_exists" : {
-		"NL": "Raid already exists!",
+		"NL": "Raid bestaat al!",
 		"DE": "Raid existiert bereits!",
 		"EN": "Raid already exists!"
 	},
@@ -370,17 +375,17 @@
 		"EN": "Create Raid in"		
 	},
 	"raid_creation_in_progress_warning" : {
-		"NL": "You can continue with the raid creation, but this will overwrite the raid which is concurrently being created and is definitely NOT RECOMMENDED!",
+		"NL": "Je kan een raid aanmaken, maar de huidig aangemaakte raid zal worden overscheven. Deze wijziging kunnen niet ongedaan gemaakt worden dit is NIET AAN TE RADEN!",
 		"DE": "Das Raid kann weiter angelegt werden, aber dies wird das Raid welches gerade zeitgleich erstellt wird überschreiben und ist daher definitiv NICHT EMPFOHLEN!",
 		"EN": "You can continue with the raid creation, but this will overwrite the raid which is concurrently being created and is definitely NOT RECOMMENDED!"		
 	},
 	"raid_creation_in_progress" : {
-		"NL": "Raid creation in progress",
+		"NL": "Raid wordt momenteel aangemaakt",
 		"DE": "Raid wird gerade erstellt",
 		"EN": "Raid creation in progress"		
 	},
 	"select_raid_level_to_continue" : {
-		"NL": "To really continue, please select raid level",
+		"NL": "Om echt door te gaan, selecteer een raid level",
 		"DE": "Um wirklich fortzufahren, bitte Raid Level auswählen",
 		"EN": "To really continue, please select raid level"		
 	},
@@ -434,6 +439,11 @@
 		"DE": "Teilen",
 		"EN": "Share"		
 	},
+	"share_with" : {
+		"NL": "Delen met",
+		"DE": "Teilen mit",
+		"EN": "Share with"
+	},
 	"set_gym_name_and_team" : {
 		"NL": "Optioneel - Gym naam and Gym Team:",
 		"DE": "Optional - Arena Name und Arena Team:",
@@ -475,17 +485,17 @@
 		"EN": "In how many minutes does the raid <b>begin</b>?"		
 	},
 	"raid_starts_when_clocktime_view" : {
-		"NL": "Clock time view",
+		"NL": "klok",
 		"DE": "Uhrzeit-Ansicht",
 		"EN": "Clock time view"
 	},
 	"raid_starts_when_minutes_view" : {
-		"NL": "Minutes view",
+		"NL": "Minuten",
 		"DE": "Minuten-Ansicht",
 		"EN": "Minutes view"
 	},
 	"raid_starts_when_view_changed" : {
-		"NL": "View changed!",
+		"NL": "Overzicht verandert!",
 		"DE": "Ansicht geändert!",
 		"EN": "View changed!"
 	},
@@ -495,17 +505,22 @@
 		"EN": "Raid is already active!"		
 	},
 	"raid_access_denied" : {
-		"NL": "You are not allowed to edit this raid!",
+		"NL": "Je hebt geen rechten om deze raid aan te passen!",
 		"DE": "Sie haben keine Berechtigung dieses Raid zu bearbeiten!",
 		"EN": "You are not allowed to edit this raid!"		
 	},
 	"no_active_raids_found" : {
-		"NL": "No active raids found in the system!",
+		"NL": "Geen actieve raids gevonden!",
 		"DE": "Aktuell sind keine laufenden Raids im System!",
 		"EN": "No active raids found in the system!"		
 	},
+	"no_active_raids" : {
+		"NL": "Geen actieve raids!",
+		"DE": "Aktuell gibt es keine Raids!",
+		"EN": "No active raids currently!"
+	},
 	"expand" : {
-		"NL": "Expand",
+		"NL": "Uitklappen",
 		"DE": "Ausklappen",
 		"EN": "Expand"		
 	},
@@ -590,62 +605,127 @@
 		"EN": "Gym name updated."		
 	},
 	"mods_details" : {
-		"NL": "Select moderator for details:",
+		"NL": "Selecteer moderator voor meer informatie:",
 		"DE": "Für Details Moderator auswählen:",
 		"EN": "Select moderator for details:"
 	},
 	"mods_add_new" : {
-		"NL": "Add new moderator:",
+		"NL": "Nieuwe moderator toevoegen:",
 		"DE": "Neuen Moderator hinzufügen:",
 		"EN": "Add new moderator:"
 	},
 	"mods_delete" : {
-		"NL": "Delete moderator:",
+		"NL": "Moderator verwijderen:",
 		"DE": "Moderator löschen:",
 		"EN": "Delete moderator:"
 	},
 	"mods_list_of_all" : {
-		"NL": "List of all moderators.",
+		"NL": "Lijst met alle moderators.",
 		"DE": "Liste aller Moderatoren.",
 		"EN": "List of all moderators."
 	},
 	"mods_list_add_delete" : {
-		"NL": "List, add or remove moderators",
+		"NL": "Lijst, toevoegen of verwijderen van moderators",
 		"DE": "Moderatoren anzeigen, hinzufügen oder löschen",
 		"EN": "List, add or remove moderators"		
 	},
 	"mods_not_found" : {
-		"NL": "Error! No moderators or users found!",
+		"NL": "Error! Geen Moderator of gebruiker gevonden!",
 		"DE": "Fehler! Keine Moderatoren oder Benutzer gefunden!",
 		"EN": "Error! No moderators or users found!"
 	},
 	"mods_saved_mod" : {
-		"NL": "Moderator saved!",
+		"NL": "Moderator opgeslagen!",
 		"DE": "Moderator gespeichert!",
 		"EN": "Moderator saved!"
 	},
 	"mods_delete_mod" : {
-		"NL": "Moderator deleted!",
+		"NL": "Moderator verwijderd!",
 		"DE": "Moderator gelöscht!",
 		"EN": "Moderator deleted!"
 	},
 	"mods_info_about_mod" : {
-		"NL": "Info about this moderator:",
+		"NL": "Informatie over deze moderator:",
 		"DE": "Infos zum diesem Moderator:",
 		"EN": "Info about this moderator:"
 	},
+	"overview_share" : {
+		"NL": "INSERT_TRANSLATION",
+		"DE": "Übersicht teilen",
+		"EN": "Share overview"
+	},
+	"overview_delete" : {
+		"NL": "INSERT_TRANSLATION",
+		"DE": "Übersicht löschen",
+		"EN": "Delete overview"
+	},
+	"raids_list_share_overview" : {
+		"NL": "INSERT_TRANSLATION",
+		"DE": "Aktive Raids als Liste anzeigen oder die Raid-Übersicht pro Chat teilen / löschen",
+		"EN": "Show active raids as list or share / delete the raid overview per chat"
+	},
+	"list_all_active_raids" : {
+		"NL": "INSERT_TRANSLATION",
+		"DE": "Alle aktiven Raids",
+		"EN": "All active raids"
+	},
+	"list_all_overviews" : {
+		"NL": "INSERT_TRANSLATION",
+		"DE": "Alle Raid-Übersichten",
+		"EN": "All raid overviews"
+	},
+	"delete_raid_overview_for_chat" : {
+		"NL": "INSERT_TRANSLATION",
+		"DE": "Raid-Übersicht löschen für",
+		"EN": "Delete raid overview for"
+	},
+	"no_overviews_found" : {
+		"NL": "INSERT_TRANSLATION",
+		"DE": "Keine Raid-Übersichten im System gefunden!",
+		"EN": "No raid overviews found in the system!"
+	},
+	"overview_successfully_deleted" : {
+		"NL": "INSERT_TRANSLATION",
+		"DE": "Raid-Übersicht wurde erfolgreich gelöscht!",
+		"EN": "Raid overview was successfully deleted!"
+	},
+	"overview_deletion_was_canceled" : {
+		"NL": "INSERT_TRANSLATION",
+		"DE": "Löschung der Raid-Übersicht wurde abgebrochen!",
+		"EN": "Deletion of the raid overview was canceled!"
+	},
+	"raid_overview_for_chat" : {
+		"NL": "INSERT_TRANSLATION",
+		"DE": "Raid-Übersicht für",
+		"EN": "Overview of raids for"
+	},
+	"successfully_shared" : {
+		"NL": "INSERT_TRANSLATION",
+		"DE": "Erfolgreich geteilt!",
+		"EN": "Successfully shared!"
+	},
+	"yes" : {
+		"NL": "Ja",
+		"DE": "Ja",
+		"EN": "Yes"
+	},
+	"no" : {
+		"NL": "Nee",
+		"DE": "Nein",
+		"EN": "No"
+	},
 	"list" : {
-		"NL": "List",
+		"NL": "Lijst",
 		"DE": "Anzeigen",
-		"EN": "List"		
+		"EN": "List"
 	},
 	"add" : {
-		"NL": "Add",
+		"NL": "Toevoegen",
 		"DE": "Hinzufügen",
 		"EN": "Add"		
 	},
 	"delete" : {
-		"NL": "Delete",
+		"NL": "Verwijder",
 		"DE": "Löschen",
 		"EN": "Delete"		
 	}

--- a/logic.php
+++ b/logic.php
@@ -1355,7 +1355,7 @@ function get_overview($update, $chats_active, $raids_active, $action = 'refresh'
             // Set the message.
             $msg = '<b>' . getTranslation('raid_overview_for_chat') . ' ' . $chat_title . ':</b>' .  CR . CR;
             $msg .= getTranslation('no_active_raids');
-            $msg .= CR . '<i>' . getTranslation('updated') . ': ' . unix2tz(time(), TIMEZONE, 'H:i:s') . '</i>';
+            $msg .= CR . CR . '<i>' . getTranslation('updated') . ': ' . unix2tz(time(), TIMEZONE, 'H:i:s') . '</i>';
 
             // Edit the message, but disable the web preview!
             debug_log('Updating overview:' . CR . 'Chat_ID: ' . $chat_id . CR . 'Message_ID: ' . $message_id);

--- a/logic.php
+++ b/logic.php
@@ -770,8 +770,8 @@ function insert_cleanup($chat_id, $message_id, $raid_id)
 function run_cleanup ($telegram = 2, $database = 2) {
     // Check configuration, cleanup of telegram needs to happen before database cleanup!
     if (CLEANUP_TIME_TG > CLEANUP_TIME_DB) {
-	debug_log('Configuration issue! Cleanup time for telegram messages needs to be lower or equal to database cleanup time!');
-	debug_log('Stopping cleanup process now!');
+	cleanup_log('Configuration issue! Cleanup time for telegram messages needs to be lower or equal to database cleanup time!');
+	cleanup_log('Stopping cleanup process now!');
 	exit;
     }
 
@@ -809,7 +809,7 @@ function run_cleanup ($telegram = 2, $database = 2) {
         }
 
         // Write to log.
-        debug_log($cleanup_jobs);
+        cleanup_log($cleanup_jobs);
 
         // Init previous raid id.
         $prev_raid_id = "FIRST_RUN";
@@ -819,10 +819,10 @@ function run_cleanup ($telegram = 2, $database = 2) {
 	    $current_raid_id = ($row['raid_id'] == 0) ? $row['cleaned'] : $row['raid_id'];
 
             // Write to log.
-            debug_log("Cleanup ID: " . $row['id']);
-            debug_log("Chat ID: " . $row['chat_id']);
-            debug_log("Message ID: " . $row['message_id']);
-            debug_log("Raid ID: " . $row['raid_id']);
+            cleanup_log("Cleanup ID: " . $row['id']);
+            cleanup_log("Chat ID: " . $row['chat_id']);
+            cleanup_log("Message ID: " . $row['message_id']);
+            cleanup_log("Raid ID: " . $row['raid_id']);
 
 	    // Get raid data only when raid_id changed compared to previous run
 	    if ($prev_raid_id != $current_raid_id) {
@@ -850,16 +850,17 @@ function run_cleanup ($telegram = 2, $database = 2) {
 	        $cleanup_time_db = 60*CLEANUP_TIME_DB;
 
 		// Write times to log.
-		debug_log("Raid end time: " . unix2tz($end,$tz,"Y-m-d H:i:s"));
-		debug_log("Raid cleanup time: " . unix2tz(($end + $cleanup_time),$tz,"Y-m-d H:i:s"));
-		debug_log("Current time: " . unix2tz($now,$tz,"Y-m-d H:i:s"));
+		cleanup_log("Current time: " . unix2tz($now,$tz,"Y-m-d H:i:s"));
+		cleanup_log("Raid end time: " . unix2tz($end,$tz,"Y-m-d H:i:s"));
+		cleanup_log("Telegram cleanup time: " . unix2tz(($end + $cleanup_time_tg),$tz,"Y-m-d H:i:s"));
+		cleanup_log("Database cleanup time: " . unix2tz(($end + $cleanup_time_db),$tz,"Y-m-d H:i:s"));
 
 		// Write unix timestamps to log.
-		debug_log("Unix timestamps:");
-		debug_log("Raid end time: " . $end);
-		debug_log("Telegram cleanup time: " . ($end + $cleanup_time_tg));
-		debug_log("Database cleanup time: " . ($end + $cleanup_time_db));
-		debug_log("Current time: " . $now);
+		cleanup_log(CR . "Unix timestamps:");
+		cleanup_log("Current time: " . $now);
+		cleanup_log("Raid end time: " . $end);
+		cleanup_log("Telegram cleanup time: " . ($end + $cleanup_time_tg));
+		cleanup_log("Database cleanup time: " . ($end + $cleanup_time_db));
 	    }
 
 	    // Time for telegram cleanup?
@@ -867,10 +868,10 @@ function run_cleanup ($telegram = 2, $database = 2) {
                 // Delete raid poll telegram message if not already deleted
 	        if ($telegram == 1 && $row['chat_id'] != 0 && $row['message_id'] != 0) {
 		    // Delete telegram message.
-                    debug_log('Deleting telegram message ' . $row['message_id'] . ' from chat ' . $row['chat_id'] . ' for raid ' . $row['raid_id']);
+                    cleanup_log('Deleting telegram message ' . $row['message_id'] . ' from chat ' . $row['chat_id'] . ' for raid ' . $row['raid_id']);
                     delete_message($row['chat_id'], $row['message_id']);
 		    // Set database values of chat_id and message_id to 0 so we know telegram message was deleted already.
-                    debug_log('Updating telegram cleanup inforamtion.');
+                    cleanup_log('Updating telegram cleanup inforamtion.');
 		    my_query(
     		    "
     		        UPDATE    cleanup
@@ -881,13 +882,13 @@ function run_cleanup ($telegram = 2, $database = 2) {
 		    );
 	        } else {
 		    if ($telegram == 1) {
-			debug_log('Telegram message is already deleted!');
+			cleanup_log('Telegram message is already deleted!');
 		    } else {
-			debug_log('Telegram cleanup was not triggered! Skipping...');
+			cleanup_log('Telegram cleanup was not triggered! Skipping...');
 		    }
 		}
 	    } else {
-		debug_log('Skipping cleanup of telegram for this raid! Cleanup time has not yet come...');
+		cleanup_log('Skipping cleanup of telegram for this raid! Cleanup time has not yet come...');
 	    }
 
 	    // Time for database cleanup?
@@ -896,7 +897,7 @@ function run_cleanup ($telegram = 2, $database = 2) {
 	        // Make sure to delete only once - raid may be in multiple channels/supergroups, but only 1 time in database
 	        if (($database == 1) && $row['raid_id'] != 0 && ($prev_raid_id != $current_raid_id)) {
 		    // Delete raid from attendance table.
-                    debug_log('Deleting attendances for raid ' . $current_raid_id);
+                    cleanup_log('Deleting attendances for raid ' . $current_raid_id);
                     my_query(
                     "
                         DELETE FROM    attendance
@@ -906,7 +907,7 @@ function run_cleanup ($telegram = 2, $database = 2) {
 
 		    // Set database value of raid_id to 0 so we know attendance info was deleted already
 		    // Use raid_id in where clause since the same raid_id can in cleanup more than once
-                    debug_log('Updating database cleanup inforamtion.');
+                    cleanup_log('Updating database cleanup inforamtion.');
                     my_query(
                     "
                         UPDATE    cleanup
@@ -917,9 +918,9 @@ function run_cleanup ($telegram = 2, $database = 2) {
                     );
 	        } else {
 		    if ($database == 1) {
-		        debug_log('Attendances are already deleted!');
+		        cleanup_log('Attendances are already deleted!');
 		    } else {
-			debug_log('Attendance cleanup was not triggered! Skipping...');
+			cleanup_log('Attendance cleanup was not triggered! Skipping...');
 		    }
 		}
 
@@ -927,7 +928,7 @@ function run_cleanup ($telegram = 2, $database = 2) {
 		// In addition trigger deletion only when previous and current raid_id are different to avoid unnecessary sql queries
 		if ($row['raid_id'] == 0 && $row['chat_id'] == 0 && $row['message_id'] == 0 && $row['cleaned'] != 0 && ($prev_raid_id != $current_raid_id)) {
 		    // Delete raid from raids table.
-		    debug_log('Deleting raid ' . $row['cleaned'] . ' from database.');
+		    cleanup_log('Deleting raid ' . $row['cleaned'] . ' from database.');
                     my_query(
                     "
                         DELETE FROM    raids
@@ -936,7 +937,7 @@ function run_cleanup ($telegram = 2, $database = 2) {
                     );
 		    
 		    // Get all cleanup jobs which will be deleted now.
-                    debug_log('Removing cleanup info from database:');
+                    cleanup_log('Removing cleanup info from database:');
 		    $rs_cl = my_query(
                     "
                         SELECT *
@@ -947,7 +948,7 @@ function run_cleanup ($telegram = 2, $database = 2) {
 
 		    // Log each cleanup ID which will be deleted.
 		    while($rs_cleanups = $rs_cl->fetch_assoc()) {
- 			debug_log('Cleanup ID: ' . $rs_cleanups['id'] . ', Former Raid ID: ' . $rs_cleanups['cleaned']);
+ 			cleanup_log('Cleanup ID: ' . $rs_cleanups['id'] . ', Former Raid ID: ' . $rs_cleanups['cleaned']);
 		    }
 
 		    // Finally delete from cleanup table.
@@ -959,13 +960,13 @@ function run_cleanup ($telegram = 2, $database = 2) {
                     );
 		} else {
 		    if ($prev_raid_id != $current_raid_id) {
-			debug_log('Time for complete removal of raid from database has not yet come.');
+			cleanup_log('Time for complete removal of raid from database has not yet come.');
 		    } else {
-			debug_log('Complete removal of raid from database was already done!');
+			cleanup_log('Complete removal of raid from database was already done!');
 		    }
 		}
 	    } else {
-		debug_log('Skipping cleanup of database for this raid! Cleanup time has not yet come...');
+		cleanup_log('Skipping cleanup of database for this raid! Cleanup time has not yet come...');
 	    }
 	
 	    // Store current raid id as previous id for next loop
@@ -973,7 +974,7 @@ function run_cleanup ($telegram = 2, $database = 2) {
         }
 
     // Write to log.
-    debug_log('Finished with cleanup process!');
+    cleanup_log('Finished with cleanup process!');
     }
 }
 
@@ -1233,7 +1234,7 @@ function send_response_vote($update, $data, $new = false)
 
     } else {
         // Edit the message.
-        edit_message($update, $msg, $keys);
+        edit_message($update, $msg, $keys, ['disable_web_page_preview' => 'true']);
         // Change message string.
         $msg = getTranslation('vote_updated');
         // Answer the callback.
@@ -1243,6 +1244,316 @@ function send_response_vote($update, $data, $new = false)
     exit;
 }
 
+/**
+ * Insert overview.
+ * @param $chat_id
+ * @param $message_id
+ */
+function insert_overview($chat_id, $message_id)
+{
+    global $db;
+
+    // Build query to check if overview details are already in database or not
+    $rs = my_query(
+        "
+        SELECT    COUNT(*)
+        FROM      overview
+          WHERE   chat_id = '{$chat_id}'
+         "
+        );
+
+    $row = $rs->fetch_row();
+
+    // Overview already in database or new
+    if (empty($row['0'])) {
+        // Build query for overview table to add overview info to database
+        debug_log('Adding new overview information to database overview list!');
+        $rs = my_query(
+            "
+            INSERT INTO   overview
+            SET           chat_id = '{$chat_id}',
+                          message_id = '{$message_id}'
+            "
+        );
+    } else {
+        // Nothing to do - overview information is already in database.
+        debug_log('Overview information is already in database! Nothing to do...');
+    }
+}
+
+/**
+ * Delete overview.
+ * @param $chat_id
+ * @param $message_id
+ */
+function delete_overview($chat_id, $message_id)
+{
+    global $db;
+
+    // Delete telegram message.
+    debug_log('Deleting overview telegram message ' . $message_id . ' from chat ' . $chat_id);
+    delete_message($chat_id, $message_id);
+
+    // Delete overview from database.
+    debug_log('Deleting overview information from database for Chat_ID: ' . $chat_id);
+    $rs = my_query(
+        "
+        DELETE FROM   overview 
+        WHERE   chat_id = '{$chat_id}'
+        "
+    );
+}
+
+/**
+ * Get overview data to Share or refresh.
+ * @param $update
+ * @param $chats_active
+ * @param $raids_active
+ * @param $action - refresh or share
+ * @param $chat_id
+ */
+function get_overview($update, $chats_active, $raids_active, $action = 'refresh', $chat_id = 0)
+{
+    // Add pseudo array for last run to active chats array
+    $last_run = array();
+    $last_run[chat_id] = 'LAST_RUN';
+    $chats_active[] = $last_run;
+
+    // Init previous chat_id
+    $previous = 'FIRST_RUN';
+
+    // Any active raids currently?
+    if (empty($raids_active)) {
+        // Init keys.
+        $keys = array();
+        $keys = [];
+
+        // Refresh active overview messages with 'no_active_raids_currently' or send 'no_active_raids_found' message to user.
+        $rs = my_query(
+            "
+            SELECT    *
+            FROM      overview
+            "
+        );
+
+        // Refresh active overview messages.
+        while ($row_overview = $rs->fetch_assoc()) {
+            $chat_id = $row_overview['chat_id'];
+            $message_id = $row_overview['message_id'];
+
+            // Get info about chat for title.
+            debug_log('Getting chat object for chat_id: ' . $row_overview['chat_id']);
+            $chat_obj = get_chat($row_overview['chat_id']);
+            $chat_title = '';
+
+            // Set title.
+            if ($chat_obj['ok'] == 'true') {
+                $chat_title = $chat_obj['result']['title'];
+                debug_log('Title of the chat: ' . $chat_obj['result']['title']);
+            }
+
+            // Set the message.
+            $msg = '<b>' . getTranslation('raid_overview_for_chat') . ' ' . $chat_title . ':</b>' .  CR . CR;
+            $msg .= getTranslation('no_active_raids');
+            $msg .= CR . '<i>' . getTranslation('updated') . ': ' . unix2tz(time(), TIMEZONE, 'H:i:s') . '</i>';
+
+            // Edit the message, but disable the web preview!
+            debug_log('Updating overview:' . CR . 'Chat_ID: ' . $chat_id . CR . 'Message_ID: ' . $message_id);
+            editMessageText($message_id, $msg, $keys, $chat_id);
+        }
+
+        // Triggered from user or cronjob?
+        if (!empty($update['callback_query']['id'])) {
+            // Send no active raids message to the user.
+            $msg = getTranslation('no_active_raids');
+
+            // Edit the message, but disable the web preview!
+            edit_message($update, $msg, $keys);
+
+            // Answer the callback.
+            answerCallbackQuery($update['callback_query']['id'], $msg);
+        }
+    
+        // Exit here.
+        exit;
+    }
+
+    // Share or refresh each chat.
+    foreach ($chats_active as $row) {
+        $current = $row['chat_id'];
+
+        // Are any raids shared?
+        if ($previous == "FIRST_RUN" && $current == "LAST_RUN") {
+            // Send no active raids message to the user.
+            $msg = getTranslation('no_active_raids_shared');
+
+            // Edit the message, but disable the web preview!
+            edit_message($update, $msg, $keys);
+
+            // Answer the callback.
+            answerCallbackQuery($update['callback_query']['id'], $msg);
+        }
+
+        // Send message if not first run and previous not current
+        if ($previous !== 'FIRST_RUN' && $previous !== $current) {
+            // Add keys.
+	    $keys = array();
+
+            // Add update timestamp to msg.
+            $msg .= '<i>' . getTranslation('updated') . ': ' . unix2tz(time(), $tz, 'H:i:s') . '</i>';
+
+            // Share or refresh?
+            if ($action == 'share') {
+                if ($chat_id == 0) {
+                    // Make sure it's not already shared
+                    $rs = my_query(
+                        "
+                        SELECT    COUNT(*)
+                        FROM      overview
+                        WHERE      chat_id = '{$previous}'
+                        "
+                    );
+
+                    $row = $rs->fetch_row();
+
+                    if (empty($row['0'])) {
+                        // Not shared yet - Share button
+                        $keys[] = [
+                            [
+                                'text'          => getTranslation('share_with') . ' ' . $chat_obj['result']['title'],
+                                'callback_data' => '0:overview_share:' . $previous
+                            ]
+                        ];
+                    } else {
+                        // Already shared - refresh button
+                        $keys[] = [
+                            [
+                                'text'          => EMOJI_REFRESH,
+                                'callback_data' => '0:overview_refresh:' . $previous
+                            ]
+                        ];
+                    }
+
+                    // Send the message, but disable the web preview!
+                    send_message($update['callback_query']['message']['chat']['id'], $msg, $keys, ['disable_web_page_preview' => 'true']);
+
+                    // Set the callback message and keys
+                    $callback_keys = array();
+                    $callback_keys = [];
+                    $callback_msg = '<b>' . getTranslation('list_all_overviews') . ':</b>';
+
+                    // Edit the message.
+                    edit_message($update, $callback_msg, $callback_keys);
+
+                    // Answer the callback.
+                    answerCallbackQuery($update['callback_query']['id'], 'OK');
+                } else {
+                    // Shared overview
+                    $keys = [];
+
+                    // Set callback message string.
+                    $msg_callback = getTranslation('successfully_shared');
+
+                    // Edit the message, but disable the web preview!
+                    edit_message($update, $msg_callback, $keys, ['disable_web_page_preview' => 'true']);
+
+                    // Answer the callback.
+                    answerCallbackQuery($update['callback_query']['id'], $msg_callback);
+
+                    // Send the message, but disable the web preview!
+                    send_message($chat_id, $msg, $keys, ['disable_web_page_preview' => 'true']);
+                }
+	    } else {
+                // Refresh overview messages.
+                $keys = [];
+
+                // Get active overviews 
+                $rs = my_query(
+                    "
+                    SELECT    message_id
+                    FROM      overview
+                    WHERE      chat_id = '{$previous}'
+                    "
+                );
+
+                // Edit text for all messages, but disable the web preview!
+                while ($row_msg_id = $rs->fetch_assoc()) {
+                    // Set message_id.
+                    $message_id = $row_msg_id['message_id'];
+                    debug_log('Updating overview:' . CR . 'Chat_ID: ' . $previous . CR . 'Message_ID: ' . $message_id);
+                    editMessageText($message_id, $msg, $keys, $previous, ['disable_web_page_preview' => 'true']);
+                }
+
+                // Answer the callback.
+                answerCallbackQuery($update['callback_query']['id'], 'OK');
+            }
+        }
+
+        // End if last run
+        if ($current == 'LAST_RUN') {
+            break;
+        }
+
+        // Create message for each raid_id
+        if($previous !== $current) {
+            // Get info about chat for username.
+            debug_log('Getting chat object for chat_id: ' . $row['chat_id']);
+            $chat_obj = get_chat($row['chat_id']);
+            $chat_username = '';
+
+            // Set username if available.
+            if ($chat_obj['ok'] == 'true' && isset($chat_obj['result']['username'])) {
+                $chat_username = $chat_obj['result']['username'];
+                debug_log('Username of the chat: ' . $chat_obj['result']['username']);
+            }
+
+            $msg = '<b>' . getTranslation('raid_overview_for_chat') . ' ' . $chat_obj['result']['title'] . ':</b>' .  CR . CR;
+        }
+
+        // Set variables for easier message building.
+        $raid_id = $row['raid_id'];
+        $pokemon = $raids_active[$raid_id]['pokemon'];
+        $gym = $raids_active[$raid_id]['gym_name'];
+        $now = $raids_active[$raid_id]['ts_now'];
+        $tz = $raids_active[$raid_id]['timezone'];
+        $start_time = $raids_active[$raid_id]['ts_start'];
+        $time_left = floor($raids_active[$raid_id]['t_left'] / 60);
+
+        // Build message and add each gym in this format - link gym_name to raid poll chat_id + message_id if possible
+        /* Example:
+         * Raid Overview from 18:18h
+         *
+         * Train Station Gym
+         * Raikou - still 0:24h
+         *
+         * Bus Station Gym
+         * Level 5 Egg opens up 18:41h
+        */
+        // Gym name.
+        $msg .= !empty($chat_username) ? '<a href="https://t.me/' . $chat_username . '/' . $row['message_id'] . '">' . htmlspecialchars($gym) . '</a>' : $gym;
+        $msg .= CR;
+
+        // Raid has not started yet - adjust time left message
+        if ($now < $start_time) {
+            $weekday_now = date('N', $now);
+            $weekday_start = date('N', $start_time);
+            $raid_day = weekday_number2name ($weekday_start);
+            if ($weekday_now == $weekday_start) {
+                $msg .= getTranslation('raid_egg_opens') . ' ' . unix2tz($start_time, $tz) . CR . CR;
+            } else {
+                $msg .= getTranslation('raid_egg_opens_day') . ' ' .  $raid_day . ' ' . getTranslation('raid_egg_opens_at') . ' ' . unix2tz($start_time, $tz) . CR . CR;
+            }
+
+        // Raid has started already
+        } else {
+            // Add time left message.
+            $msg .= $pokemon . ' — <b>' . getTranslation('still') . ' ' . floor($time_left / 60) . ':' . str_pad($time_left % 60, 2, '0', STR_PAD_LEFT) . 'h</b>' . CR . CR;
+        }
+
+        // Prepare next iteration
+        $previous = $current;
+    }
+}
 /**
  * Convert unix timestamp to time string by timezone settings.
  * @param $unix
@@ -1350,7 +1661,7 @@ function show_raid_poll($raid)
     $time_left = floor($raid['t_left'] / 60);
     if ( strpos(str_pad($time_left % 60, 2, '0', STR_PAD_LEFT) , '-' ) !== false ) {
 	// $time_left = 'beendet'; <-- REPLACED BY $tl_msg, so if clause below is still working ($time_left < 0)
-        $tl_msg = '<b> ' . getTranslation('raid_done') . '</b>';
+        $tl_msg = '<b>' . getTranslation('raid_done') . '</b>';
     } else {
 	// Replace $time_left with $tl_msg too
         $tl_msg = ' — <b>' . getTranslation('still') . ' ' . floor($time_left / 60) . ':' . str_pad($time_left % 60, 2, '0', STR_PAD_LEFT) . 'h</b>';

--- a/modules/list_raids.php
+++ b/modules/list_raids.php
@@ -1,0 +1,92 @@
+<?php
+// Write to log.
+debug_log('LIST_RAIDS');
+
+// Build query.
+$rs = my_query(
+    "
+    SELECT    timezone
+    FROM      raids
+      WHERE   id = (
+                  SELECT    raid_id
+                  FROM      attendance
+                    WHERE   user_id = {$update['callback_query']['from']['id']}
+                  ORDER BY  id DESC LIMIT 1
+              )
+    "
+);
+
+// Get row.
+$row = $rs->fetch_assoc();
+
+// No data found.
+if (!$row) {
+    //sendMessage($update['message']['from']['id'], 'Can\'t determine your location, please participate in at least 1 raid');
+    //exit;
+    $tz = TIMEZONE;
+} else {
+    $tz = $row['timezone'];
+}
+
+// Build query.
+$request = my_query(
+    "
+    SELECT    *,
+              UNIX_TIMESTAMP(end_time)                        AS ts_end,
+              UNIX_TIMESTAMP(start_time)                      AS ts_start,
+              UNIX_TIMESTAMP(NOW())                           AS ts_now,
+              UNIX_TIMESTAMP(end_time)-UNIX_TIMESTAMP(NOW())  AS t_left
+    FROM      raids
+      WHERE   end_time>NOW()
+        AND   timezone='{$tz}'
+    ORDER BY  end_time ASC LIMIT 20
+    "
+);
+
+// Count results.
+$count = 0;
+
+// Get raids.
+while ($raid = $request->fetch_assoc()) {
+
+    // Counter++
+    $count = $count + 1;
+
+    // Create keys array.
+    $keys = [
+        [
+            [
+                'text'          => getTranslation('expand'),
+                'callback_data' => $raid['id'] . ':vote_refresh:0',
+            ]
+        ]
+    ];
+
+    // Get message.
+    $msg = show_raid_poll_small($raid);
+
+    // Send message.
+    send_message($update['callback_query']['from']['id'], $msg, $keys, ['reply_markup' => ['selective' => true, 'one_time_keyboard' => true]]);
+}
+    
+// Set message.
+if($count == 0) {
+    //sendMessage($update['callback_query']['from']['id'], '<b>' . getTranslation('no_active_raids_found') . '</b>');
+    $msg = '<b>' . getTranslation('no_active_raids_found') . '</b>';
+} else {
+    $msg = '<b>' . getTranslation('list_all_active_raids') . ':</b>';
+}
+
+// Set message.
+$keys = [];
+
+// Edit message.
+edit_message($update, $msg, $keys, false);
+
+// Build callback message string.
+$callback_response = 'OK';
+
+// Answer callback.
+answerCallbackQuery($update['callback_query']['id'], $callback_response);
+
+exit;

--- a/modules/overview_delete.php
+++ b/modules/overview_delete.php
@@ -1,0 +1,106 @@
+<?php
+// Write to log.
+debug_log('OVERVIEW_DELETE');
+debug_log($data);
+
+// Delete or list to deletion?
+$chat_id = 0;
+$chat_id = $data['arg'];
+
+// Get all or specific overview
+if ($chat_id == 0) {
+    $request_overviews = my_query(
+        "
+        SELECT    *
+        FROM      overview
+        "
+    );
+
+    // Init keys.
+    $keys = array();
+
+    // Count results.
+    $count = 0;
+
+    while ($rowOverviews = $request_overviews->fetch_assoc()) {
+        // Counter++
+        $count = $count + 1;
+
+        // Get info about chat for title.
+        debug_log('Getting chat object for chat_id: ' . $rowOverviews['chat_id']);
+        $chat_obj = get_chat($rowOverviews['chat_id']);
+        $chat_title = '';
+
+        // Set title.
+        if ($chat_obj['ok'] == 'true') {
+            $chat_title = $chat_obj['result']['title'];
+            debug_log('Title of the chat: ' . $chat_obj['result']['title']);
+        }
+
+        // Build message string.
+        $msg = '<b>' . getTranslation('delete_raid_overview_for_chat') . ' ' . $chat_title . '?</b>';
+
+        // Set keys - Delete button.
+        $keys[] = [         
+            [                   
+                'text'          => getTranslation('yes'),
+                'callback_data' => '0:overview_delete:' . $rowOverviews['chat_id']
+            ],
+            [
+                'text'          => getTranslation('no'),
+                'callback_data' => '0:overview_delete:1'
+            ]
+        ];
+
+        // Send the message, but disable the web preview!
+        send_message($update['callback_query']['message']['chat']['id'], $msg, $keys);
+    }
+
+    // Set message.
+    if($count == 0) {
+        $callback_msg = '<b>' . getTranslation('no_overviews_found') . '</b>';
+    } else {
+        $callback_msg = '<b>' . getTranslation('list_all_overviews') . ':</b>';
+    }
+} else if ($chat_id == 1) {
+    // Write to log.
+    debug_log('Deletion of the raid overview was canceled!');
+
+    // Set message.
+    $callback_msg = '<b>' . getTranslation('overview_deletion_was_canceled') . '</b>';
+} else {
+    // Write to log.
+    debug_log('Triggering deletion of overview for Chat_ID ' . $chat_id);
+
+    // Get chat and message ids for overview.
+    $request_overviews = my_query(
+        "
+        SELECT    *
+        FROM      overview
+        WHERE     chat_id = '{$chat_id}'
+        "
+    );
+
+    $overview = $request_overviews->fetch_assoc();
+
+    // Delete overview
+    delete_overview($overview['chat_id'], $overview['message_id']);
+
+    // Set message.
+    $callback_msg = '<b>' . getTranslation('overview_successfully_deleted') . '</b>';
+}
+
+// Init keys.
+$callback_keys = array();
+
+// Set keys.
+$callback_keys = [];
+
+// Edit message.
+edit_message($update, $callback_msg, $callback_keys, false);
+
+// Build callback message string.
+$callback_response = 'OK';
+
+// Answer callback.
+answerCallbackQuery($update['callback_query']['id'], $callback_response);

--- a/modules/overview_refresh.php
+++ b/modules/overview_refresh.php
@@ -1,0 +1,138 @@
+<?php
+// Write to log.
+debug_log('OVERVIEW_REFRESH');
+debug_log($data);
+
+// Get chat ID from data
+$chat_id = 0;
+$chat_id = $data['arg'];
+
+// $update present?
+if (isset($update['callback_query']['from']['id'])) {
+    // Build query.
+    $rs = my_query(
+        "
+        SELECT    timezone
+        FROM      raids
+          WHERE   id = (
+                      SELECT    raid_id
+                      FROM      attendance
+                        WHERE   user_id = {$update['callback_query']['from']['id']}
+                      ORDER BY  id DESC LIMIT 1
+                  )
+        "
+    );
+
+    // Get row.
+    $row = $rs->fetch_assoc();
+
+    // No data found.
+    if (!$row) {
+        //sendMessage($update['message']['from']['id'], 'Can\'t determine your location, please participate in at least 1 raid');
+        //exit;
+        $tz = TIMEZONE;
+    } else {
+        $tz = $row['timezone'];
+    }
+} else {
+    $tz = TIMEZONE;
+}
+
+// Get active raids.
+$request_active_raids = my_query(
+    "
+    SELECT    *,
+              UNIX_TIMESTAMP(end_time)                        AS ts_end,
+              UNIX_TIMESTAMP(start_time)                      AS ts_start,
+              UNIX_TIMESTAMP(NOW())                           AS ts_now,
+              UNIX_TIMESTAMP(end_time)-UNIX_TIMESTAMP(NOW())  AS t_left
+    FROM      raids
+      WHERE   end_time>NOW()
+        AND   timezone='{$tz}'
+    ORDER BY  end_time ASC
+    "
+);
+
+// Count active raids.
+$count_active_raids = 0;
+
+// Init empty active raids and raid_ids array.
+$raids_active = array();
+$raid_ids_active = array();
+
+// Get all active raids into array.
+while ($rowRaids = $request_active_raids->fetch_assoc()) {
+    // Use current raid_id as key for raids array
+    $current_raid_id = $rowRaids['id'];
+    $raids_active[$current_raid_id] = $rowRaids;
+
+    // Build array with raid_ids to query cleanup table later
+    $raid_ids_active[] = $rowRaids['id'];
+
+    // Counter for active raids
+    $count_active_raids = $count_active_raids + 1;
+}
+
+// Write to log.
+debug_log('Active raids:');
+debug_log($raids_active);
+
+// Init empty active chats array.
+$chats_active = array();
+
+// Make sure we have active raids.
+if ($count_active_raids > 0) {
+    // Implode raid_id's of all active raids.
+    $raid_ids_active = implode(',',$raid_ids_active);
+
+    // Write to log.
+    debug_log('IDs of active raids:');
+    debug_log($raid_ids_active);
+
+    // Get all or specific overview
+    if ($chat_id == 0) {
+        $request_overviews = my_query(
+            "
+            SELECT    chat_id
+            FROM      overview
+            "
+        );
+    } else {
+        $request_overviews = my_query(
+            "
+            SELECT    chat_id
+            FROM      overview
+            WHERE     chat_id = '{$chat_id}'
+            "
+        );
+    }
+
+    while ($rowOverviews = $request_overviews->fetch_assoc()) {
+        // Set chat_id.
+        $chat_id = $rowOverviews['chat_id'];
+
+        // Get chats. 
+        $request_active_chats = my_query(
+            "
+            SELECT    *
+            FROM      cleanup
+              WHERE   raid_id IN ({$raid_ids_active})
+	      AND     chat_id = '{$chat_id}'
+              ORDER BY chat_id, FIELD(raid_id, {$raid_ids_active})
+            "
+        );
+
+        // Get all chats.    
+        while ($rowChats = $request_active_chats->fetch_assoc()) {
+            $chats_active[] = $rowChats;
+        }
+    }
+}
+
+// Write to log.
+debug_log('Active chats:');
+debug_log($chats_active);
+
+// Get raid overviews
+get_overview($update, $chats_active, $raids_active, $action = 'refresh', $chat_id);
+exit;

--- a/modules/overview_share.php
+++ b/modules/overview_share.php
@@ -1,0 +1,125 @@
+<?php
+// Write to log.
+debug_log('OVERVIEW_SHARE');
+debug_log($data);
+
+// Get chat ID from data
+$chat_id = 0;
+$chat_id = $data['arg'];
+
+// Build query.
+$rs = my_query(
+    "
+    SELECT    timezone
+    FROM      raids
+      WHERE   id = (
+                  SELECT    raid_id
+                  FROM      attendance
+                    WHERE   user_id = {$update['callback_query']['from']['id']}
+                  ORDER BY  id DESC LIMIT 1
+              )
+    "
+);
+
+// Get row.
+$row = $rs->fetch_assoc();
+
+// No data found.
+if (!$row) {
+    //sendMessage($update['message']['from']['id'], 'Can\'t determine your location, please participate in at least 1 raid');
+    //exit;
+    $tz = TIMEZONE;
+} else {
+    $tz = $row['timezone'];
+}
+
+// Get active raids.
+$request_active_raids = my_query(
+    "
+    SELECT    *,
+              UNIX_TIMESTAMP(end_time)                        AS ts_end,
+              UNIX_TIMESTAMP(start_time)                      AS ts_start,
+              UNIX_TIMESTAMP(NOW())                           AS ts_now,
+              UNIX_TIMESTAMP(end_time)-UNIX_TIMESTAMP(NOW())  AS t_left
+    FROM      raids
+      WHERE   end_time>NOW()
+        AND   timezone='{$tz}'
+    ORDER BY  end_time ASC
+    "
+);
+
+// Count active raids.
+$count_active_raids = 0;
+
+// Init empty active raids and raid_ids array.
+$raids_active = array();
+$raid_ids_active = array();
+
+// Get all active raids into array.
+while ($rowRaids = $request_active_raids->fetch_assoc()) {
+    // Use current raid_id as key for raids array
+    $current_raid_id = $rowRaids['id'];
+    $raids_active[$current_raid_id] = $rowRaids;
+
+    // Build array with raid_ids to query cleanup table later
+    $raid_ids_active[] = $rowRaids['id'];
+
+    // Counter for active raids
+    $count_active_raids = $count_active_raids + 1;
+}
+
+// Write to log.
+debug_log('Active raids:');
+debug_log($raids_active);
+
+// Init empty active chats array.
+$chats_active = array();
+
+// Make sure we have active raids.
+if ($count_active_raids > 0) {
+    // Implode raid_id's of all active raids.
+    $raid_ids_active = implode(',',$raid_ids_active);
+
+    // Write to log.
+    debug_log('IDs of active raids:');
+    debug_log($raid_ids_active);
+
+    // Get chat for active raids.
+    if ($chat_id == 0) {
+        $request_active_chats = my_query(
+            "
+            SELECT    *
+            FROM      cleanup
+              WHERE   raid_id IN ({$raid_ids_active})
+              ORDER BY chat_id, FIELD(raid_id, {$raid_ids_active})
+            "
+        );
+    } else {
+        $request_active_chats = my_query(
+            "
+            SELECT    *
+            FROM      cleanup
+              WHERE   raid_id IN ({$raid_ids_active})
+	      AND     chat_id = '{$chat_id}'
+              ORDER BY chat_id, FIELD(raid_id, {$raid_ids_active})
+            "
+        );
+    }
+
+    // Get all chats.    
+    while ($rowChats = $request_active_chats->fetch_assoc()) {
+        $chats_active[] = $rowChats;
+    }
+}
+
+// Write to log.
+debug_log('Active chats:');
+debug_log($chats_active);
+
+// Get raid overviews
+if ($chat_id == 0) {
+    get_overview($update, $chats_active, $raids_active, $action = 'share');
+} else {
+    get_overview($update, $chats_active, $raids_active, $action = 'share', $chat_id);
+}
+exit;

--- a/raid-pokemon-bot.sql
+++ b/raid-pokemon-bot.sql
@@ -53,6 +53,15 @@ CREATE TABLE `gyms` (
   PRIMARY KEY (`id`)
 ) ENGINE=InnoDB AUTO_INCREMENT=100 DEFAULT CHARSET=utf8;
 
+/*Table structure for table `overview` */
+
+CREATE TABLE `overview` (
+  `id` int(10) unsigned NOT NULL AUTO_INCREMENT,
+  `chat_id` bigint(20) signed NOT NULL,
+  `message_id` bigint(20) unsigned NOT NULL,
+  PRIMARY KEY (`id`)
+) ENGINE=InnoDB AUTO_INCREMENT=100 DEFAULT CHARSET=utf8;
+
 /*Table structure for table `raids` */
 
 CREATE TABLE `raids` (


### PR DESCRIPTION
Add raids overview feature.
Overview of raids can be shared with chats to which raids have been shared.
Overviews can be shared and deleted via /list
Requires database update (overview table) and introduces a new config.php variable - so update config.php too.
To update overview via cronjob by calling the overview_refresh module:
`curl -k -d '{"callback_query":{"data":"0:overview_refresh:0"}}' https://localhost/bot_subdirectory/index.php?apikey=111111111:AABBccddEEFFggHHiijjKKLLmmnnOOPPqq`