### PR TITLE
bug on row 535 was 5star had to be 1 star.

### DIFF
--- a/logic.php
+++ b/logic.php
@@ -532,7 +532,7 @@ function raid_edit_start_keys($id)
                 'callback_data' => $id . ':edit:2'
             ],
             [
-                'text'          => getTranslation('5stars'),
+                'text'          => getTranslation('1stars'),
                 'callback_data' => $id . ':edit:1'
             ]
 */        ]


### PR DESCRIPTION
We use the 1,2 egg for the EX triggers.