### PR TITLE
Raid sharing - CONFIG.PHP UPDATE REQUIRED!

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Use https://www.miniwebtool.com/sha512-hash-generator/ and set `CONFIG_HASH` to 
 
 ## Sharing raids
 
-You can share raid polls wth any chat in Telegram via a share button.
+You can share raid polls with any chat in Telegram via a share button.
 
 Sharing raid polls can be restricted, so only moderators or users or both can be allowed to share a raid poll.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,32 @@ Bot Settings:
 
 Use https://www.miniwebtool.com/sha512-hash-generator/ and set `CONFIG_HASH` to hashed value of your token (make sure it is lowecase)
 
+## Sharing raids
+
+You can share raid polls wth any chat in Telegram via a share button.
+
+Sharing raid polls can be restricted, so only moderators or users or both can be allowed to share a raid poll.
+
+Therefore it is possible, via a comma-separated list, to specify the chats the raid polls can be shared with.
+
+A few examples:
+
+#### Restrict sharing for moderators and users to chats -100111222333 and @RaidChat
+
+`define('SHARE_MODERATORS', false);`
+
+`define('SHARE_USERS', false);`
+
+`define('SHARE_CHATS', '-100111222333,@RaidChat');`
+
+#### Allow moderators to share with any chat, restrict sharing for users to chat @RaidChat
+
+`define('SHARE_MODERATORS', true);`
+
+`define('SHARE_USERS', false);`
+
+`define('SHARE_CHATS', '@RaidChat');`
+
 ## Raid times
 
 There are several options to configure the times related to the raid polls:
@@ -163,14 +189,28 @@ As a member of `BOT_ACCESS` you can create raid polls, update your own raid poll
 Telegram Users can only vote on raid polls, but have no access to other bot functions (unless you configured it for public access).
 
 
-| Access        | Database  | Raid poll |                                      |                  | Pokemon                       |                               | Gym             |                  | Moderators       |                 |                    | Help             |
-|---------------|-----------|-----------|--------------------------------------|------------------|-------------------------------|-------------------------------|-----------------|------------------|------------------|-----------------|--------------------|------------------|
-|               |           | **Vote**  | **Create** `/start`, `/raid`, `/new` | **List** `/list` | **All raid polls** `/pokemon` | **Own raid polls** `/pokemon` | **Name** `/gym` | **Team** `/team` | **List** `/mods` | **Add** `/mods` | **Delete** `/mods` | **Show** `/help` |
-| MAINTAINER_ID |           | Yes       | Yes                                  | Yes              | Yes                           | Yes                           | Yes             | Yes              | Yes              | Yes             | Yes                | Yes              |
-| BOT_ADMINS    |           | Yes       | Yes                                  | Yes              | Yes                           | Yes                           | Yes             | Yes              | Yes              | Yes             | Yes                | Yes              |
-| BOT_ACCESS    | Moderator | Yes       | Yes                                  |                  | Yes                           | Yes                           | Yes             | Yes              |                  |                 |                    | Yes              |
-| BOT_ACCESS    | User      | Yes       | Yes                                  |                  |                               | Yes                           |                 | Yes              |                  |                 |                    | Yes              |
-| Telegram      | User      | Yes       |                                      |                  |                               |                               |                 |                  |                  |                 |                    |                  |
+| Access:    |            |                                  | MAINTAINER_ID | BOT_ADMINS | BOT_ACCESS | BOT_ACCESS | Telegram |
+|-----------|------------|----------------------------------|---------------|------------|------------|------------|----------|
+| Database: |            |                                  |               |            | Moderator  | User       | User     |
+|           | **Area**   | **Action and /command**          |               |            |            |            |          |
+|           | Raid poll  | Vote                             | Yes           | Yes        | Yes        | Yes        | Yes      |
+|           |            | Create `/start`, `/raid`, `/new` | Yes           | Yes        | Yes        | Yes        |          |
+|           |            | List `/list`                     | Yes           | Yes        | Yes        | Yes        |          |
+|           |            | Overview `/list`                 | Yes           | Yes        |            |            |          |
+|           |            | Delete ALL raid polls `/delete`  | Yes           | Yes        | Yes        |            |          |
+|           |            | Delete OWN raid polls `/delete`  | Yes           | Yes        | Yes        | Yes        |          |
+|           |            |                                  |               |            |            |            |          |
+|           | Pokemon    | ALL raid polls `/pokemon`        | Yes           | Yes        | Yes        |            |          |
+|           |            | OWN raid polls `/pokemon`        | Yes           | Yes        | Yes        | Yes        |          |
+|           |            |                                  |               |            |            |            |          |
+|           | Gym        | Name `/gym`                      | Yes           | Yes        | Yes        |            |          |
+|           |            | Team `/team`                     | Yes           | Yes        | Yes        | Yes        |          |
+|           |            |                                  |               |            |            |            |          |
+|           | Moderators | List `/mods`                     | Yes           | Yes        |            |            |          |
+|           |            | Add `/mods`                      | Yes           | Yes        |            |            |          |
+|           |            | Delete `/mods`                   | Yes           | Yes        |            |            |          |
+|           |            |                                  |               |            |            |            |          |
+|           | Help       | Show `/help`                     | Yes           | Yes        | Yes        | Yes        |          |
 
 # Updates
 
@@ -216,7 +256,7 @@ Example input: `/raid Entei,52.514545,13.350095,60,Mystic,Siegessäule,Großer S
 
 Update pokemon of an existing raid poll. With this command you can change the pokemon raid boss from e.g. "Level 5 Egg" to "Lugia" once the egg has hatched.
 
-You can only change the pokemon raid boss of raid polls you created yourself. You cannot modify the pokemon of raid polls from other bot users.
+Based on your access to the bot, you may can only change the pokemon raid boss of raid polls you created yourself and cannot modify the pokemon of raid polls from other bot users.
 
 
 #### Command: /new
@@ -231,6 +271,13 @@ Example input: `/new 52.514545,13.350095`
 #### Command: /list 
 
 The bot will allow you to via a list of the last 20 active raids, share and delete all raids which got shared to channels as a raid overview.
+
+
+#### Command: /delete
+
+Delete an existing raid poll. With this command you can delete a raid poll from telegram and the database. Use with care!
+
+Based on your access to the bot, you may can only delete raid polls you created yourself and cannot delete raid polls from other bot users.
 
 
 #### Command: /team
@@ -253,5 +300,4 @@ Check your bot logfile and other related log files, e.g. apache/httpd log, php l
 
 * New gyms: Adding gyms to database without creating a raid via /raid
 * Preferred pokemon raid boss: When multiple level 5 raids are available, e.g. Lugia and Zapdos, add buttons to tell that you're coming a) only if Lugia, b) only if Zapdos, c) independently of the pokemon
-* Delete raids: Allow BOT_ADMINS to delete raids
 * Delete incomplete raids automatically: When a bot user starts to create a raid via /start, but does not finish the raid creation, incomplete raid data is stored in the raids table. A method to automatically delete them without interfering with raids just being created would be nice.

--- a/config.php.example
+++ b/config.php.example
@@ -19,6 +19,10 @@ define('BOT_NAME',          '@RaidPokemonBot');
 define('BOT_ADMINS',        ''); // optional
 define('BOT_ACCESS',        ''); // optional
 
+define('SHARE_MODERATORS',  true);
+define('SHARE_USERS',       true);
+define('SHARE_CHATS',       '');
+
 define('RAID_LOCATION',     false); // send location as message in addition to raid poll message
 define('RAID_SLOTS',        '15'); // minutes
 define('RAID_LAST_START',   '10'); // minutes before RAID ends

--- a/constants.php
+++ b/constants.php
@@ -55,6 +55,7 @@ $pokemon = array(
         getTranslation('rhydon'),
         getTranslation('golem'),
         getTranslation('absol'),
+        getTranslation('aggron'),
         getTranslation('egg_4')
     ),
     '3' => array(

--- a/index.php
+++ b/index.php
@@ -90,6 +90,8 @@ if (isset($update['cleanup']) && CLEANUP == true) {
         // Run cleanup
         cleanup_log('Calling cleanup process now!');
         run_cleanup($telegram, $database);
+    } else {
+        cleanup_log('Error! Wrong cleanup secret supplied!', '!');
     }
     // Exit after cleanup
     exit();

--- a/language.json
+++ b/language.json
@@ -877,6 +877,12 @@
 		"EN": "Raid was successfully deleted!",
 		"PT-BR": "Raid deletado com sucesso!"
 	},
+	"action_aborted" : {
+		"NL": "Het proces is afgebroken!",
+		"DE": "Der Vorgang wurde abgebrochen!",
+		"EN": "The process was aborted!",
+		"PT-BR": "O processo foi abortado!"
+	},
 	"yes" : {
 		"NL": "Ja",
 		"DE": "Ja",
@@ -888,6 +894,12 @@
 		"DE": "Nein",
 		"EN": "No",
 		"PT-BR": "Não"
+	},
+	"abort" : {
+		"NL": "Afbreken",
+		"DE": "Abbrechen",
+		"EN": "Abort",
+		"PT-BR": "Abortar"
 	},
 	"list" : {
 		"NL": "Lijst",

--- a/language.json
+++ b/language.json
@@ -90,7 +90,7 @@
 		"EN": "Tuesday",
 		"PT-BR": "Terça-feira"
 	},
-	"wensday" : {
+	"wednesday" : {
 		"NL": "Woensdag",
 		"DE": "Mittwoch",
 		"EN": "Wednesday",
@@ -108,7 +108,7 @@
 		"EN": "Friday",
 		"PT-BR": "Sexta-feira"
 	},
-	"saterday" : {
+	"saturday" : {
 		"NL": "Zaterdag",
 		"DE": "Samstag",
 		"EN": "Saturday",
@@ -322,6 +322,12 @@
 		"DE": "Absol",
 		"EN": "Absol",
 		"PT-BR": "Absol"
+	},
+	"aggron" : {
+		"NL": "Aggron",
+		"DE": "Stolloss",
+		"EN": "Aggron",
+		"PT-BR": "Aggron"
 	},
 	"tyranitar" : {
 		"NL": "Tyranitar",

--- a/logic.php
+++ b/logic.php
@@ -1745,7 +1745,7 @@ function weekday_number2name ($weekdaynumber)
 		$weekday = getTranslation('tuesday');
 		break;
 	    case 3: 
-		$weekday = getTranslation('wensday');
+		$weekday = getTranslation('wednesday');
 		break;
 	    case 4: 
 		$weekday = getTranslation('thursday');
@@ -1754,7 +1754,7 @@ function weekday_number2name ($weekdaynumber)
 		$weekday = getTranslation('friday');
 		break;
 	    case 6: 
-		$weekday = getTranslation('saterday');
+		$weekday = getTranslation('saturday');
 		break;
 	    case 7: 
 		$weekday = getTranslation('sunday');

--- a/modules/edit_left.php
+++ b/modules/edit_left.php
@@ -10,25 +10,36 @@ debug_log($data);
 // Set the id.
 $id = $data['id'];
 
+// Set the user id.
+$userid = $update['callback_query']['from']['id'];
+
 // Build query.
 my_query(
     "
     UPDATE    raids
-    SET       end_time = DATE_ADD(start_time, INTERVAL {$data['arg']} MINUTE)
+    SET       user_id = {$userid},
+              end_time = DATE_ADD(start_time, INTERVAL {$data['arg']} MINUTE)
       WHERE   id = {$id}
     "
 );
 
 if ($update['message']['chat']['type'] == 'private' || $update['callback_query']['message']['chat']['type'] == 'private') {
-    // Set the keys.
+    // Init keys.
+    $keys = array();
+
+    // Add delete to keys.
     $keys = [
         [
             [
-                'text'                => getTranslation('share'),
-                'switch_inline_query' => strval($id)
+                'text'          => getTranslation('delete'),
+                'callback_data' => $id . ':raids_delete:0'
             ]
         ]
     ];
+
+    // Add keys to share.
+    $keys_share = share_keys($id, $userid);
+    $keys = array_merge($keys, $keys_share);
 
     // Get raid times.
     $rs = my_query(

--- a/modules/exit.php
+++ b/modules/exit.php
@@ -1,0 +1,19 @@
+<?php
+// Write to log.
+debug_log('EXIT()');
+debug_log($update);
+debug_log($data);
+
+// Set empty keys.
+$keys = [];
+
+// Build message string.
+$msg = getTranslation('action_aborted');
+
+// Edit the message.
+edit_message($update, $msg, $keys);
+
+// Answer callback.
+answerCallbackQuery($update['callback_query']['id'], $msg);
+
+exit();

--- a/modules/raid_share.php
+++ b/modules/raid_share.php
@@ -1,0 +1,48 @@
+<?php
+// Check raid access.
+raid_access_check($update, $data);
+
+// Write to log.
+debug_log('raid_share()');
+debug_log($update);
+debug_log($data);
+
+// Get raid id.
+$id = $data['id'];
+
+// Get chat id.
+$chat = $data['arg'];
+
+// Get raid.
+$rs = my_query(
+    "
+    SELECT    *, 
+                          UNIX_TIMESTAMP(start_time)                      AS ts_start,
+                          UNIX_TIMESTAMP(end_time)                        AS ts_end,
+                          UNIX_TIMESTAMP(NOW())                           AS ts_now,
+                          UNIX_TIMESTAMP(end_time)-UNIX_TIMESTAMP(NOW())  AS t_left
+            FROM      raids
+              WHERE   id = {$id}
+    "
+);
+
+// Fetch the row.
+$raid = $rs->fetch_assoc();
+
+// Get text and keys.
+$text = show_raid_poll($raid);
+$keys = keys_vote($raid);
+
+// Send the message.
+send_message($chat, $text, $keys, ['disable_web_page_preview' => 'true']);
+
+// Set callback keys and message
+$callback_msg = getTranslation('successfully_shared');
+
+// Edit message.
+edit_message($update, $callback_msg, $callback_keys, false);
+
+// Answer callback.
+answerCallbackQuery($update['callback_query']['id'], $callback_msg);
+
+exit;

--- a/modules/raids_list.php
+++ b/modules/raids_list.php
@@ -74,6 +74,10 @@ while ($raid = $request->fetch_assoc()) {
         ]
     ];
 
+    // Add keys to share.
+    $keys_share = share_keys($raid['id'], $update['callback_query']['from']['id']);
+    $keys = array_merge($keys, $keys_share);
+
     // Get message.
     $msg = show_raid_poll_small($raid);
 


### PR DESCRIPTION
CONFIG.PHP UPDATE REQUIRED!

Allow to restrict sharing of raids.
Add same sharing method to raids as we use for raid overviews.
Some minor improvements and fixes.
Updated readme to include latest changes.