### PR TITLE
Improvements and fixes to the new pokemon keys feature

### DIFF
--- a/language.json
+++ b/language.json
@@ -331,7 +331,7 @@
   	},
   	  	"jynx" : {
     		"NL": "Jynx",
-    		"DE": "Jynx",
+    		"DE": "Rossana",
     		"EN": "Jynx",
 		"PT-BR": "Jynx"
   	},
@@ -341,33 +341,33 @@
     		"EN": "Azumarill",
 		"PT-BR": "Azumarill"
   	},
-  	"piloswine" : {
+	"piloswine" : {
     		"NL": "Piloswine",
-    		"DE": "Piloswine",
+    		"DE": "Keifel",
     		"EN": "Piloswine",
 		"PT-BR": "Piloswine"
   	},
-  	  	"salamence" : {
+  	"salamence" : {
     		"NL": "Salamence",
-    		"DE": "Salamence",
+    		"DE": "Brutalanda",
     		"EN": "Salamence",
 		"PT-BR": "Salamence"
   	},
   	"feraligatr" : {
     		"NL": "Feraligatr",
-    		"DE": "Feraligatr",
+    		"DE": "Impergator",
     		"EN": "Feraligatr",
 		"PT-BR": "Feraligatr"
   	},
-  	  	"meganium" : {
+  	"meganium" : {
     		"NL": "Meganium",
-    		"DE": "Meganium",
+    		"DE": "Meganie",
     		"EN": "Meganium",
 		"PT-BR": "Meganium"
   	},
   	"typhlosion" : {
     		"NL": "Typhlosion",
-    		"DE": "Typhlosion",
+    		"DE": "Tornupto",
     		"EN": "Typhlosion",
 		"PT-BR": "Typhlosion"
   	},


### PR DESCRIPTION
Beside the obvious improvements and fixes: I changed the logic to count attendances as the old logic (e.g. used in show_raid_poll small or the overview) was sometimes faulty. Now SQL query is used to calculate the attendances and not a faulty loop in php to sum up the people voted/coming.